### PR TITLE
feat: Add navigation by months to expenses page

### DIFF
--- a/symfony/src/Controller/RouteController.php
+++ b/symfony/src/Controller/RouteController.php
@@ -36,13 +36,18 @@ class RouteController extends BaseController
         return $this->renderWithRoutes('about.html.twig');
     }
 
-    #[Route('/expenses', name: 'expenses', options: ['friendly_name' => 'Wydatki', 'order' => 2])]
-    public function expenses(): Response
+    #[Route('/expenses/{year?}/{month?}', name: 'expenses', requirements: ['year' => '\d{4}', 'month' => '\d{1,2}'], options: ['friendly_name' => 'Wydatki', 'order' => 2])]
+    public function expenses(int $year = null, int $month = null): Response
     {
-        $expenses = $this->expensesService->getAllExpenses();
-        return $this->renderWithRoutes('expenses/index.html.twig', [
+        $year = $year ?? (int)date('Y');
+        $month = $month ?? (int)date('m');
+
+        $expenses = $this->expensesService->getExpensesByMonth($year, $month);
+        $navigationMonths = $this->expensesService->getNavigationMonths($year, $month);
+
+        return $this->renderWithRoutes('expenses/index.html.twig', array_merge([
             'expenses' => $expenses,
-        ]);
+        ], $navigationMonths));
     }
 
     #[Route('/expenses/add', name: 'expenses_add', methods: ['GET', 'POST'])]

--- a/symfony/src/Repository/ExpenseRepository.php
+++ b/symfony/src/Repository/ExpenseRepository.php
@@ -18,4 +18,15 @@ class ExpenseRepository extends ServiceEntityRepository
     {
         parent::__construct($registry, Expense::class);
     }
+
+    public function findByMonth(\DateTime $startDate, \DateTime $endDate): array
+    {
+        $qb = $this->createQueryBuilder('e')
+            ->where('e.date >= :startDate')
+            ->andWhere('e.date < :endDate')
+            ->setParameter('startDate', $startDate->format('Y-m-d'))
+            ->setParameter('endDate', $endDate->format('Y-m-d'));
+
+        return $qb->getQuery()->getResult();
+    }
 }

--- a/symfony/src/Service/ExpenseService.php
+++ b/symfony/src/Service/ExpenseService.php
@@ -21,6 +21,14 @@ class ExpenseService
         return $this->entityManager->getRepository(Expense::class)->findAll();
     }
 
+    public function getExpensesByMonth(int $year, int $month): array
+    {
+        $startDate = new \DateTime("$year-$month-01");
+        $endDate = (clone $startDate)->modify('+1 month');
+
+        return $this->entityManager->getRepository(Expense::class)->findByMonth($startDate, $endDate);
+    }
+
     public function addExpense(Request $request): void
     {
         $expense = new Expense();
@@ -69,5 +77,22 @@ class ExpenseService
     public function getAllCategories(): array
     {
         return $this->entityManager->getRepository(Category::class)->findAll();
+    }
+
+    public function getNavigationMonths(int $year, int $month): array
+    {
+        $prevMonth = ($month == 1) ? 12 : $month - 1;
+        $prevYear = ($month == 1) ? $year - 1 : $year;
+        $nextMonth = ($month == 12) ? 1 : $month + 1;
+        $nextYear = ($month == 12) ? $year + 1 : $year;
+
+        return [
+            'year' => $year,
+            'month' => str_pad($month, 2, '0', STR_PAD_LEFT),
+            'prevYear' => $prevYear,
+            'prevMonth' => str_pad($prevMonth, 2, '0', STR_PAD_LEFT),
+            'nextYear' => $nextYear,
+            'nextMonth' => str_pad($nextMonth, 2, '0', STR_PAD_LEFT),
+        ];
     }
 }

--- a/symfony/templates/expenses/index.html.twig
+++ b/symfony/templates/expenses/index.html.twig
@@ -4,12 +4,30 @@
 
 {% block content %}
     <div class="container mx-auto">
-        <h1 class="text-xl font-bold mb-4">Expenses</h1>
+        <h1 class="text-xl font-bold my-4">Expenses</h1>
 
-        <a href="{{ path('expenses_add') }}"
-           class="my-8 inline-block w-auto bg-transparent hover:bg-blue-500 text-blue-700 font-semibold hover:text-white py-2 px-4 border border-blue-500 hover:border-transparent rounded">
-            Add New Expense
-        </a>
+        <nav class="flex justify-between items-center mb-4" aria-label="Month navigation">
+            <div class="flex space-x-4">
+                <a href="{{ path('expenses', { year: prevYear, month: prevMonth }) }}"
+                   class="inline-block w-auto bg-transparent hover:bg-blue-500 text-blue-700 font-semibold hover:text-white py-2 px-4 border border-blue-500 hover:border-transparent rounded">
+                    &lt; Previous
+                </a>
+
+                <span class="inline-block w-auto bg-gray-200 text-gray-700 font-semibold py-2 px-4 rounded">
+                    {{ month }} - {{ year }}
+                </span>
+
+                <a href="{{ path('expenses', { year: nextYear, month: nextMonth }) }}"
+                   class="inline-block w-auto bg-transparent hover:bg-blue-500 text-blue-700 font-semibold hover:text-white py-2 px-4 border border-blue-500 hover:border-transparent rounded">
+                    Next &gt;
+                </a>
+            </div>
+
+            <a href="{{ path('expenses_add') }}"
+               class="inline-block w-auto bg-transparent hover:bg-blue-500 text-blue-700 font-semibold hover:text-white py-2 px-4 border border-blue-500 hover:border-transparent rounded">
+                Add New Expense
+            </a>
+        </nav>
 
         <div class="table-container">
             <table class="min-w-full leading-normal">
@@ -63,7 +81,6 @@
             </table>
         </div>
     </div>
-
 {% endblock %}
 
 {% block javascripts %}


### PR DESCRIPTION
- Implement navigation controls to switch between months
- Display current selected month and year in MM - YYYY format
- Add previous and next month buttons
- Utilize semantic HTML5 elements with <nav> for navigation container
- Refactor code to move month calculation logic to ExpensesService
- Ensure month values are always displayed as two-digit numbers

Closes #17