### PR TITLE
feat: Add fixtures for menu items and test expenses

### DIFF
--- a/symfony/composer.json
+++ b/symfony/composer.json
@@ -27,6 +27,7 @@
     },
     "require-dev": {
         "doctrine/doctrine-fixtures-bundle": "^3.6",
+        "fakerphp/faker": "^1.23",
         "symfony/maker-bundle": "^1.59"
     },
     "config": {

--- a/symfony/src/Controller/BaseController.php
+++ b/symfony/src/Controller/BaseController.php
@@ -9,13 +9,11 @@ use App\Repository\MenuRepository;
 
 class BaseController extends AbstractController
 {
-    protected RouterInterface $router;
-    protected MenuRepository $menuRepository;
-
-    public function __construct(RouterInterface $router, MenuRepository $menuRepository)
+    public function __construct(
+        protected RouterInterface $router,
+        protected MenuRepository  $menuRepository
+    )
     {
-        $this->router = $router;
-        $this->menuRepository = $menuRepository;
     }
 
     protected function renderWithRoutes(string $view, array $parameters = [], ?Response $response = null): Response

--- a/symfony/src/Controller/MenuController.php
+++ b/symfony/src/Controller/MenuController.php
@@ -11,17 +11,12 @@ use Symfony\Component\Routing\RouterInterface;
 
 class MenuController extends BaseController
 {
-    private EntityManagerInterface $entityManager;
-
     public function __construct(
-        EntityManagerInterface $entityManager,
-        RouterInterface $router,
-        MenuRepository $menuRepository
+        private EntityManagerInterface $entityManager,
+        protected RouterInterface      $router,
+        protected MenuRepository       $menuRepository
     )
     {
-        parent::__construct($router, $menuRepository);
-        $this->entityManager = $entityManager;
-        $this->menuRepository = $menuRepository;
     }
 
     #[Route('/admin/menu', name: 'admin_menu')]
@@ -41,7 +36,7 @@ class MenuController extends BaseController
 
         foreach ($this->menuRepository->findAll() as $menu) {
             $id = $menu->getId();
-            $isActive = isset($data['menu'][$id]['activated']) ? (bool)$data['menu'][$id]['activated'] : false;
+            $isActive = isset($data['menu'][$id]['activated']) && $data['menu'][$id]['activated'];
             $menu->setActivated($isActive);
             $this->entityManager->persist($menu);
         }

--- a/symfony/src/Controller/RouteController.php
+++ b/symfony/src/Controller/RouteController.php
@@ -12,16 +12,12 @@ use Symfony\Component\HttpFoundation\Request;
 
 class RouteController extends BaseController
 {
-    private ExpenseService $expensesService;
-
     public function __construct(
         RouterInterface $router,
-        ExpenseService $expensesService,
-        MenuRepository $menuRepository,
+        private ExpenseService $expensesService,
+        protected MenuRepository $menuRepository,
     )
     {
-        parent::__construct($router, $menuRepository);
-        $this->expensesService = $expensesService;
     }
 
     #[Route('/', name: 'home', options: ['friendly_name' => 'Start', 'order' => 1])]

--- a/symfony/src/DataFixtures/ExpenseFixtures.php
+++ b/symfony/src/DataFixtures/ExpenseFixtures.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\DataFixtures;
+
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Persistence\ObjectManager;
+use App\Entity\Expense;
+use App\Entity\Category;
+use Faker\Factory;
+
+class ExpenseFixtures extends Fixture
+{
+    public function load(ObjectManager $manager)
+    {
+        $faker = Factory::create();
+
+        // Pobranie kategorii z bazy danych
+        $categories = $manager->getRepository(Category::class)->findAll();
+
+        // Upewnij się, że są dostępne kategorie
+        if (empty($categories)) {
+            throw new \Exception('No categories found. Please load CategoryFixtures first.');
+        }
+
+        // Definiowanie większej liczby nazw wydatków dla różnych kategorii
+        $expenseNames = [
+            'Jedzenie' => ['Groceries', 'Restaurant', 'Snacks', 'Beverages', 'Lunch', 'Dinner', 'Breakfast', 'Fast Food', 'Catering', 'Bakery'],
+            'Czynsz' => ['Monthly Rent', 'Lease Payment', 'Security Deposit', 'Rent Insurance'],
+            'Media' => ['Electricity Bill', 'Water Bill', 'Gas Bill', 'Internet Bill', 'Cable TV Bill', 'Phone Bill', 'Garbage Collection'],
+            'Rozrywka' => ['Movie Tickets', 'Concert', 'Games', 'Streaming Subscription', 'Museum', 'Amusement Park', 'Sports Event', 'Theater'],
+            'Podróże' => ['Flight Tickets', 'Hotel Booking', 'Taxi', 'Fuel', 'Car Rental', 'Bus Ticket', 'Train Ticket', 'Travel Insurance'],
+            'Zdrowie' => ['Doctor Visit', 'Medication', 'Health Insurance', 'Dental Care', 'Eye Care', 'Hospital Bill', 'Fitness Membership', 'Therapy'],
+            'Edukacja' => ['Books', 'Online Course', 'School Fees', 'Stationery', 'Tuition', 'Workshop', 'Seminar', 'College Fees'],
+            'Zakupy' => ['Clothing', 'Electronics', 'Groceries', 'Furniture', 'Home Decor', 'Toys', 'Beauty Products', 'Accessories', 'Books', 'Pet Supplies'],
+            'Inne' => ['Miscellaneous', 'Gift', 'Donation', 'Charity', 'Event', 'Subscription', 'Membership Fee', 'Bank Fee', 'Late Fee', 'Other']
+        ];
+
+        // Dodanie 100 wydatków
+        for ($i = 0; $i < 100; $i++) {
+            $category = $faker->randomElement($categories);
+            $expense = new Expense();
+            $expense->setName($faker->randomElement($expenseNames[$category->getNamePolish()]));
+            $expense->setAmount($faker->randomFloat(2, 10, 1000));
+            $expense->setDate($faker->dateTimeBetween('-6 months', 'now'));
+            $expense->setPaymentDate($faker->optional()->dateTimeBetween('-6 months', 'now'));
+            $expense->setPaymentStatus($faker->randomElement(['unpaid', 'paid', 'partially_paid']));
+            $expense->setCategory($category);
+            $manager->persist($expense);
+        }
+
+        $manager->flush();
+    }
+}

--- a/symfony/src/DataFixtures/MenuFixtures.php
+++ b/symfony/src/DataFixtures/MenuFixtures.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\DataFixtures;
+
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Persistence\ObjectManager;
+use App\Entity\Menu;
+
+class MenuFixtures extends Fixture
+{
+    public function load(ObjectManager $manager)
+    {
+        // Definiowanie pozycji menu
+        $menus = [
+            [
+                'routeName' => 'home',
+                'friendlyName' => 'Home',
+                'path' => '/',
+                'order' => 1,
+                'activated' => true,
+            ],
+            [
+                'routeName' => 'expenses',
+                'friendlyName' => 'Expenses',
+                'path' => '/expenses',
+                'order' => 2,
+                'activated' => true,
+            ],
+            [
+                'routeName' => 'categories',
+                'friendlyName' => 'Categories',
+                'path' => '/categories',
+                'order' => 3,
+                'activated' => true,
+            ],
+            [
+                'routeName' => 'admin_menu',
+                'friendlyName' => 'Menu setup',
+                'path' => '/admin/menu',
+                'order' => 4,
+                'activated' => true,
+            ],
+            [
+                'routeName' => 'about',
+                'friendlyName' => 'About',
+                'path' => '/about',
+                'order' => 5,
+                'activated' => true,
+            ],
+        ];
+
+        foreach ($menus as $menuData) {
+            $menu = new Menu();
+            $menu->setRouteName($menuData['routeName']);
+            $menu->setFriendlyName($menuData['friendlyName']);
+            $menu->setPath($menuData['path']);
+            $menu->setOrder($menuData['order']);
+            $menu->setActivated($menuData['activated']);
+            $manager->persist($menu);
+        }
+
+        $manager->flush();
+    }
+}

--- a/symfony/src/Entity/Menu.php
+++ b/symfony/src/Entity/Menu.php
@@ -3,7 +3,6 @@
 namespace App\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
-use Symfony\Component\Validator\Constraints as Assert;
 
 #[ORM\Entity(repositoryClass: "App\Repository\MenuRepository")]
 class Menu
@@ -22,7 +21,7 @@ class Menu
     #[ORM\Column(type: "string", length: 255)]
     private $path;
 
-    #[ORM\Column(type: "integer")]
+    #[ORM\Column(type: "integer", name: "menu_order")]
     private $order;
 
     #[ORM\Column(type: "boolean")]
@@ -89,4 +88,3 @@ class Menu
         return $this;
     }
 }
-


### PR DESCRIPTION
- Added MenuFixtures to initialize default menu items including Home, Expenses, Categories, Menu setup, and About.
- Created ExpenseFixtures to populate the database with 100 test expense entries across various categories such as Food, Rent, Utilities, Entertainment, Travel, Health, Education, Shopping, and Other.
- Ensured fixtures are registered and loaded in the correct order for seamless initialization.