### PR TITLE
Optimize user roles: use NULL instead of empty array for better DB pe…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,5 +47,18 @@ services:
       MYSQL_USER: symfony
       MYSQL_PASSWORD: symfony
 
+  phpmyadmin:
+    image: phpmyadmin/phpmyadmin:latest
+    container_name: phpmyadmin_symfony
+    ports:
+      - "8080:80"
+    environment:
+      PMA_HOST: db
+      PMA_PORT: 3306
+      PMA_USER: symfony
+      PMA_PASSWORD: symfony
+    depends_on:
+      - db
+
 volumes:
   db_data:

--- a/symfony/migrations/Version20251220065312.php
+++ b/symfony/migrations/Version20251220065312.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20251220065312 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE expense CHANGE user_id user_id INT NOT NULL');
+        $this->addSql('ALTER TABLE user CHANGE roles roles JSON DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE expense CHANGE user_id user_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE user CHANGE roles roles JSON NOT NULL');
+    }
+}

--- a/symfony/src/Controller/RegistrationController.php
+++ b/symfony/src/Controller/RegistrationController.php
@@ -76,7 +76,7 @@ class RegistrationController extends BaseController
             if (empty($errors)) {
                 $user = new User();
                 $user->setEmail($email);
-                $user->setRoles([]); // Will get ROLE_USER from getRoles() method
+                $user->setRoles(null); // NULL means default roles will be applied
 
                 // Hash the password
                 $hashedPassword = $passwordHasher->hashPassword($user, $password);

--- a/symfony/src/DataFixtures/UserFixtures.php
+++ b/symfony/src/DataFixtures/UserFixtures.php
@@ -39,7 +39,7 @@ class UserFixtures extends Fixture
         // Create regular user
         $user = new User();
         $user->setEmail('user@example.com');
-        $user->setRoles(['ROLE_USER']);
+        $user->setRoles(null); // NULL means default roles will be applied
         $user->setPassword($this->passwordHasher->hashPassword($user, 'user123'));
 
         $manager->persist($user);

--- a/symfony/src/Entity/User.php
+++ b/symfony/src/Entity/User.php
@@ -22,8 +22,8 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     /**
      * @var list<string> The user roles
      */
-    #[ORM\Column]
-    private array $roles = [];
+    #[ORM\Column(nullable: true)]
+    private ?array $roles = null;
 
     /**
      * @var string The hashed password
@@ -63,7 +63,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
      */
     public function getRoles(): array
     {
-        $roles = $this->roles;
+        $roles = $this->roles ?? [];
         // guarantee every user at least has ROLE_USER
         $roles[] = 'ROLE_USER';
 


### PR DESCRIPTION
…rformance

- Change User entity roles column to nullable
- Update getRoles() method to handle NULL values
- Set NULL roles for new users instead of empty array in registration
- Update user fixtures to use NULL for default roles
- Add database migration for roles column nullability
- Add phpMyAdmin to docker-compose for database management